### PR TITLE
Add modtek.overrides.json, Settings.json and support

### DIFF
--- a/ModTek/ModTek.cs
+++ b/ModTek/ModTek.cs
@@ -403,7 +403,7 @@ namespace ModTek
                 }
                 catch (Exception e)
                 {
-                    Log($"Caught exception while parsing {MOD_JSON_NAME} at path {modDefPath}");
+                    Log($"Caught exception while parsing {MOD_JSON_NAME} at path {modDefPath} in {modDirectory}");
                     Log($"\t{e.Message}\n\t{e.StackTrace}");
                     continue;
                 }

--- a/ModTek/ModTek.cs
+++ b/ModTek/ModTek.cs
@@ -113,6 +113,17 @@ namespace ModTek
             ModDBPath = Path.Combine(DatabaseDirectory, MDD_FILE_NAME);
             DBCachePath = Path.Combine(DatabaseDirectory, DB_CACHE_FILE_NAME);
 
+            // creates the directories above it as well
+            Directory.CreateDirectory(CacheDirectory);
+            Directory.CreateDirectory(DatabaseDirectory);
+
+            // create log file, overwritting if it's already there
+            using (var logWriter = File.CreateText(LogPath))
+            {
+                logWriter.WriteLine($"ModTek v{Assembly.GetExecutingAssembly().GetName().Version} -- {DateTime.Now}");
+            }
+
+
             if (!overrideLoaded)
             {
                 if (File.Exists(Path.Combine(ModDirectory, MODTEK_OVERRIDES_JSON_NAME)))
@@ -130,15 +141,7 @@ namespace ModTek
                 }
             }
 
-            // creates the directories above it as well
-            Directory.CreateDirectory(CacheDirectory);
-            Directory.CreateDirectory(DatabaseDirectory);
 
-            // create log file, overwritting if it's already there
-            using (var logWriter = File.CreateText(LogPath))
-            {
-                logWriter.WriteLine($"ModTek v{Assembly.GetExecutingAssembly().GetName().Version} -- {DateTime.Now}");
-            }
 
             // create all of the caches
             dbCache = LoadOrCreateDBCache(DBCachePath);

--- a/modtek.overrides.json
+++ b/modtek.overrides.json
@@ -1,0 +1,10 @@
+{
+    "BTMLAddBindableEscapeKey": {
+        "Settings": {
+            "escapeMouseButton": 5
+        }
+    },
+    "ExclusiveFilters": {
+        "Enabled": false
+    }
+}


### PR DESCRIPTION
### What made you do this?
I bumped against this when I was looking at how to preserve user's mod settings after an update of a mod from source. I took a stab at a proof of concept here for solving this issue, based on the feedback above and my brain.

### Why are you doing it?
1. Move user settings outside the mod directory (allow for updates to replace all files in mod directory)
2. Separate mod info (`mod.json`) from mod settings (`settings.json`)
3. Enable a standard "mod info", "mod settings", "user overrides" structure to make updates/etc using BMI (http://github.com/gponick/bmi) tool easier.  

### How are you doing it?
1. Add a new file, `modtek.overrides.json` in `\Mods\` that contains settings that override anything found in `\<ModName>\`
2. Add a new file, `\<ModName>\settings.json`, which overrides any settings found in `\<ModName>\mod.json` (to maintain backwards compatibility)

### What else did you consider?
1. A `<modname>.overrides.json` in `\Mods` (one override file per mod) instead of one override file total (I find this less clean)
2. Upon installing a mod, create an entry in the master overrides file (I think this is a job for a tool outside Modtek, tbh)

### Besides the obvious, what else do we get?
1. A single-point-of-entry for a Mod Launcher / Settings Editor
2. A finalized, "merged" settings dictionary can be output in the .modtek directory which we can use for debugging
3. Not sure if it's doable without, but with this setup - a ModTek "mod" that allows json settings to be reloaded on command would be much more easily created (as ModTek can just have an interface you implement that has the associated command - since the mod settings are now formalized and live in specific places) and have the settings reflected in live (for .dll mods, obviously, with their own settings, not JSON mods).

Ultimately, my plans for BMI include a "bmi troubleshoot" which will grab all mod versions, ModTek Version, BTML version, BT version, and associated log files, and make a zip for the user to upload to us. I also plan on having BMI not just have a CLI but a frontend (think CKAN) and integrating (if possible) with Nexus Mod Manager and Nexus Mods. 