### PR TITLE
Optional Dependencies

### DIFF
--- a/ModTek/IModDef.cs
+++ b/ModTek/IModDef.cs
@@ -19,6 +19,7 @@ namespace ModTek
 
         HashSet<string> DependsOn { get; set; }
         HashSet<string> ConflictsWith { get; set; }
+        HashSet<string> OptionalDependencies { get; set; }
 
         string DLL { get; set; }
         string DLLEntryPoint { get; set; }

--- a/ModTek/IModDef.cs
+++ b/ModTek/IModDef.cs
@@ -19,7 +19,7 @@ namespace ModTek
 
         HashSet<string> DependsOn { get; set; }
         HashSet<string> ConflictsWith { get; set; }
-        HashSet<string> OptionalDependencies { get; set; }
+        HashSet<string> OptionallyDependsOn { get; set; }
 
         string DLL { get; set; }
         string DLLEntryPoint { get; set; }

--- a/ModTek/ModDef.cs
+++ b/ModTek/ModDef.cs
@@ -34,7 +34,7 @@ namespace ModTek
         // load order
         public HashSet<string> DependsOn { get; set; } = new HashSet<string>();
         public HashSet<string> ConflictsWith { get; set; } = new HashSet<string>();
-        public HashSet<string> OptionalDependencies { get; set; } = new HashSet<string>();
+        public HashSet<string> OptionallyDependsOn { get; set; } = new HashSet<string>();
 
         // adding and running code
         public string DLL { get; set; }

--- a/ModTek/ModDef.cs
+++ b/ModTek/ModDef.cs
@@ -34,6 +34,7 @@ namespace ModTek
         // load order
         public HashSet<string> DependsOn { get; set; } = new HashSet<string>();
         public HashSet<string> ConflictsWith { get; set; } = new HashSet<string>();
+        public HashSet<string> OptionalDependencies { get; set; } = new HashSet<string>();
 
         // adding and running code
         public string DLL { get; set; }

--- a/ModTek/ModTek.cs
+++ b/ModTek/ModTek.cs
@@ -172,10 +172,10 @@ namespace ModTek
             // add optional dependencies if they are present
             foreach (var modDef in modDefs.Values)
             {
-                if (modDef.OptionalDependencies.Count == 0)
+                if (modDef.OptionallyDependsOn.Count == 0)
                     continue;
 
-                foreach (var optDep in modDef.OptionalDependencies)
+                foreach (var optDep in modDef.OptionallyDependsOn)
                 {
                     if (modDefs.ContainsKey(optDep))
                         modDef.DependsOn.Add(optDep);


### PR DESCRIPTION
via conversation with @Amechwarrior 

This will allow mods to specify other mods as dependencies only when they are also present. Note that `LoadOrder.json` is authoritative, and dependencies are not respected if the mods are already present in `LoadOrder.json`, which might be something we want to fix, since user updated mods could specify new dependency graph stuff and it won't be respected by the load order code.

We probably would want to change that right?