### PR TITLE
[Performance] Feature/workforfullframe

### DIFF
--- a/ModTek/ProgressPanel.cs
+++ b/ModTek/ProgressPanel.cs
@@ -53,11 +53,25 @@ namespace ModTek
                 this.WorkList.AddLast(work);
             }
 
+            static double lost = 0;
             IEnumerator RunWorkList()
             {
                 foreach (var workFunc in WorkList) {
                     IEnumerator<ProgressReport> workEnumerator = workFunc.Invoke();
-                    while (workEnumerator.MoveNext())
+                   
+                    bool Next()
+                    {
+                        var sw = Stopwatch.StartNew();
+                        var didWork = false;
+                        var desiredFrameTime = 33.0;  // 30 fps - Steals a bit of cpu time from unity renderer
+
+                        // We want to work for the full duration of a frame, not one item per frame.
+                        while ((didWork = workEnumerator.MoveNext()) && sw.Elapsed.TotalMilliseconds < desiredFrameTime) { }
+
+                        return didWork;
+                    }
+
+                    while (Next())
                     {
                         ProgressReport report = workEnumerator.Current;
                         this.Slider.value = report.Progress;

--- a/ModTek/ProgressPanel.cs
+++ b/ModTek/ProgressPanel.cs
@@ -52,8 +52,7 @@ namespace ModTek
             {
                 this.WorkList.AddLast(work);
             }
-
-            static double lost = 0;
+            
             IEnumerator RunWorkList()
             {
                 foreach (var workFunc in WorkList) {

--- a/ModTek/ProgressPanel.cs
+++ b/ModTek/ProgressPanel.cs
@@ -55,16 +55,19 @@ namespace ModTek
             
             IEnumerator RunWorkList()
             {
+                var sw = new Stopwatch();
                 foreach (var workFunc in WorkList) {
                     IEnumerator<ProgressReport> workEnumerator = workFunc.Invoke();
                    
                     bool Next()
                     {
-                        var sw = Stopwatch.StartNew();
                         var didWork = false;
                         var desiredFrameTime = 33.0;  // 30 fps - Steals a bit of cpu time from unity renderer
 
+                        sw.Restart();
+
                         // We want to work for the full duration of a frame, not one item per frame.
+                        // Enumerator is checked first because we always want it to run at least once.
                         while ((didWork = workEnumerator.MoveNext()) && sw.Elapsed.TotalMilliseconds < desiredFrameTime) { }
 
                         return didWork;


### PR DESCRIPTION
@m22spencer:
>Some of the modtek workloads are very light, and end up consuming far less than a full frame worth of time to process. Due to the progress report only processing one item per frame this ends up with some lost time.
>Currently, this fix only reduces load times by about 3.5s with a RogueTech install, but every little bit helps.