### PR TITLE
Swap to relative paths in MergeCache/TypeCache/dbCache

### DIFF
--- a/ModTek/MergeCache.cs
+++ b/ModTek/MergeCache.cs
@@ -21,17 +21,30 @@ namespace ModTek
         public string GetOrCreateCachedEntry(string originalPath, List<string> mergePaths)
         {
             originalPath = Path.GetFullPath(originalPath);
+            var relativePath = ModTek.GetRelativePath(originalPath, ModTek.GameDirectory);
 
-            if (!CachedEntries.ContainsKey(originalPath) || !CachedEntries[originalPath].MatchesPaths(originalPath, mergePaths))
+            // remove old entries using absolute path
+            if (CachedEntries.ContainsKey(originalPath))
+            {
+                CachedEntries[relativePath] = CachedEntries[originalPath];
+                CachedEntries.Remove(originalPath);
+
+                // clean up old entries absolute path in merges and cachepath
+                CachedEntries[relativePath].CachePath = ModTek.GetRelativePath(CachedEntries[relativePath].CachePath, ModTek.GameDirectory);
+                foreach (var merge in CachedEntries[relativePath].Merges)
+                    merge.Path = ModTek.GetRelativePath(merge.Path, ModTek.GameDirectory);
+            }
+
+            if (!CachedEntries.ContainsKey(relativePath) || !CachedEntries[relativePath].MatchesPaths(originalPath, mergePaths))
             {
                 // create new cache entry; substring is to get rid of the path seperator -.-
-                var cachePath = Path.GetFullPath(Path.Combine(ModTek.CacheDirectory, originalPath.Replace(ModTek.GameDirectory, "").Substring(1)));
-                var cachedEntry = new CacheEntry(cachePath, originalPath, mergePaths);
+                var cachedAbsolutePath = Path.GetFullPath(Path.Combine(ModTek.CacheDirectory, originalPath.Replace(ModTek.GameDirectory, "").Substring(1)));
+                var cachedEntry = new CacheEntry(cachedAbsolutePath, originalPath, mergePaths);
 
                 if (cachedEntry.HasErrors)
                     return null;
 
-                CachedEntries[originalPath] = cachedEntry;
+                CachedEntries[relativePath] = cachedEntry;
 
                 Log($"\tMerge performed: {Path.GetFileName(originalPath)}. Now cached.");
             }
@@ -40,8 +53,8 @@ namespace ModTek
                 Log($"\tLoaded cached merge: {Path.GetFileName(originalPath)}.");
             }
 
-            CachedEntries[originalPath].CacheHit = true;
-            return CachedEntries[originalPath].CachePath;
+            CachedEntries[relativePath].CacheHit = true;
+            return CachedEntries[relativePath].CacheAbsolutePath;
         }
 
         /// <summary>
@@ -52,19 +65,19 @@ namespace ModTek
         {
             // remove all of the cache that we didn't use
             var unusedMergePaths = new List<string>();
-            foreach (var cachedEntry in CachedEntries)
-                if (!cachedEntry.Value.CacheHit)
-                    unusedMergePaths.Add(cachedEntry.Key);
+            foreach (var cachedEntryKVP in CachedEntries)
+                if (!cachedEntryKVP.Value.CacheHit)
+                    unusedMergePaths.Add(cachedEntryKVP.Key);
 
             foreach (var unusedMergePath in unusedMergePaths)
             {
-                var cachePath = CachedEntries[unusedMergePath].CachePath;
+                var cacheAbsolutePath = CachedEntries[unusedMergePath].CacheAbsolutePath;
                 CachedEntries.Remove(unusedMergePath);
 
-                if (File.Exists(cachePath))
-                    File.Delete(cachePath);
+                if (File.Exists(cacheAbsolutePath))
+                    File.Delete(cacheAbsolutePath);
 
-                var directory = Path.GetDirectoryName(cachePath);
+                var directory = Path.GetDirectoryName(cacheAbsolutePath);
                 if (directory != null && Directory.GetFiles(directory).Length == 0)
                     Directory.Delete(directory);
             }
@@ -74,20 +87,36 @@ namespace ModTek
 
         internal class CacheEntry
         {
+            public string CachePath { get; set; }
+            public DateTime OriginalTime { get; set; }
+            public List<PathTimeTuple> Merges { get; set; } = new List<PathTimeTuple>();
+
+            [JsonIgnore] internal string CacheAbsolutePath
+            {
+                get
+                {
+                    if (string.IsNullOrEmpty(_cacheAbsolutePath))
+                        _cacheAbsolutePath = ModTek.ResolvePath(CachePath, ModTek.GameDirectory);
+
+                    return _cacheAbsolutePath;
+                }
+            }
+            [JsonIgnore] private string _cacheAbsolutePath;
             [JsonIgnore] internal bool CacheHit; // default is false
             [JsonIgnore] internal string ContainingDirectory;
             [JsonIgnore] internal bool HasErrors; // default is false
+
 
             [JsonConstructor]
             public CacheEntry()
             {
             }
 
-            public CacheEntry(string path, string originalPath, List<string> mergePaths)
+            public CacheEntry(string absolutePath, string originalPath, List<string> mergePaths)
             {
-                CachePath = path;
-                ContainingDirectory = Path.GetDirectoryName(path);
-                OriginalPath = originalPath;
+                _cacheAbsolutePath = absolutePath;
+                CachePath = ModTek.GetRelativePath(absolutePath, ModTek.GameDirectory);
+                ContainingDirectory = Path.GetDirectoryName(absolutePath);
                 OriginalTime = File.GetLastWriteTimeUtc(originalPath);
 
                 if (string.IsNullOrEmpty(ContainingDirectory))
@@ -111,11 +140,11 @@ namespace ModTek
                 }
 
                 foreach (var mergePath in mergePaths)
-                    Merges.Add(new PathTimeTuple(mergePath, File.GetLastWriteTimeUtc(mergePath)));
+                    Merges.Add(new PathTimeTuple(ModTek.GetRelativePath(mergePath, ModTek.GameDirectory), File.GetLastWriteTimeUtc(mergePath)));
 
                 Directory.CreateDirectory(ContainingDirectory);
 
-                using (var writer = File.CreateText(path))
+                using (var writer = File.CreateText(absolutePath))
                 {
                     // merge all of the merges
                     foreach (var mergePath in mergePaths)
@@ -160,19 +189,14 @@ namespace ModTek
                 }
             }
 
-            public string CachePath { get; set; }
-            public string OriginalPath { get; set; }
-            public DateTime OriginalTime { get; set; }
-            public List<PathTimeTuple> Merges { get; set; } = new List<PathTimeTuple>();
-
             internal bool MatchesPaths(string originalPath, List<string> mergePaths)
             {
                 // must have an existing cached json
-                if (!File.Exists(CachePath))
+                if (!File.Exists(CacheAbsolutePath))
                     return false;
 
                 // must have the same original file
-                if (OriginalPath != originalPath || File.GetLastWriteTimeUtc(originalPath) != OriginalTime)
+                if (File.GetLastWriteTimeUtc(originalPath) != OriginalTime)
                     return false;
 
                 // must match number of merges
@@ -182,12 +206,12 @@ namespace ModTek
                 // if all paths match with write times, we match
                 for (var index = 0; index < mergePaths.Count; index++)
                 {
-                    var mergePath = mergePaths[index];
-                    var mergeTime = File.GetLastWriteTimeUtc(mergePath);
-                    var cachedMergePath = Merges[index].Path;
+                    var mergeAbsolutePath = mergePaths[index];
+                    var mergeTime = File.GetLastWriteTimeUtc(mergeAbsolutePath);
+                    var cachedMergeAboslutePath = ModTek.ResolvePath(Merges[index].Path, ModTek.GameDirectory);
                     var cachedMergeTime = Merges[index].Time;
 
-                    if (mergePath != cachedMergePath || mergeTime != cachedMergeTime)
+                    if (mergeAbsolutePath != cachedMergeAboslutePath || mergeTime != cachedMergeTime)
                         return false;
                 }
 

--- a/ModTek/ModTek.cs
+++ b/ModTek/ModTek.cs
@@ -292,14 +292,14 @@ namespace ModTek
                     return;
                 }
 
-                var entryPath = Path.Combine(modDef.Directory, entry.Path);
+                var entryPath = Path.GetFullPath(Path.Combine(modDef.Directory, entry.Path));
                 if (Directory.Exists(entryPath))
                 {
                     // path is a directory, add all the files there
                     var files = Directory.GetFiles(entryPath, "*", SearchOption.AllDirectories).Where(filePath => !FileIsOnDenyList(filePath));
                     foreach (var filePath in files)
                     {
-                        var childModDef = new ModDef.ManifestEntry(entry, filePath, InferIDFromFile(filePath));
+                        var childModDef = new ModDef.ManifestEntry(entry, Path.GetFullPath(filePath), InferIDFromFile(filePath));
                         potentialAdditions.Add(childModDef);
                     }
                 }
@@ -524,6 +524,42 @@ namespace ModTek
         }
 
 
+        // PATHING
+        public static string ResolvePath(string path, string rootPathToUse)
+        {
+            path = path.Replace("{{Mods}}", ModsDirectory);
+
+            if (!Path.IsPathRooted(path))
+                path = Path.Combine(rootPathToUse, path);
+
+            return Path.GetFullPath(path);
+        }
+
+        public static string GetRelativePath(string path, string rootPath)
+        {
+            if (!Path.IsPathRooted(path))
+                return path;
+
+            rootPath = Path.GetFullPath(rootPath);
+            if (rootPath.Last() != Path.DirectorySeparatorChar)
+                rootPath += Path.DirectorySeparatorChar;
+
+            var pathUri = new Uri(Path.GetFullPath(path), UriKind.Absolute);
+            var rootUri = new Uri(rootPath, UriKind.Absolute);
+
+            if (pathUri.Scheme != rootUri.Scheme)
+                return path;
+
+            var relativeUri = rootUri.MakeRelativeUri(pathUri);
+            var relativePath = Uri.UnescapeDataString(relativeUri.ToString());
+
+            if (pathUri.Scheme.Equals("file", StringComparison.InvariantCultureIgnoreCase))
+                relativePath = relativePath.Replace(Path.AltDirectorySeparatorChar, Path.DirectorySeparatorChar);
+
+            return relativePath;
+        }
+
+
         // JSON HANDLING
         /// <summary>
         ///     Create JObject from string, removing comments and adding commas first.
@@ -619,26 +655,60 @@ namespace ModTek
             return cache;
         }
 
-        internal static List<string> GetTypesFromCacheOrManifest(VersionManifest manifest, string path)
+        internal static List<string> GetTypesFromCache(string absolutePath)
         {
-            if (typeCache.ContainsKey(path))
+            var relativePath = GetRelativePath(absolutePath, GameDirectory);
+
+            if (typeCache.ContainsKey(relativePath))
+                return typeCache[relativePath];
+
+            if (typeCache.ContainsKey(absolutePath))
             {
-                return typeCache[path];
+                // found a cache path at an absolute path, make sure to clean it up
+                typeCache[relativePath] = typeCache[absolutePath];
+                typeCache.Remove(absolutePath);
+                return typeCache[relativePath];
             }
 
+            return null;
+        }
+
+        internal static List<string> GetTypesFromCacheOrManifest(VersionManifest manifest, string absolutePath)
+        {
+            var types = GetTypesFromCache(absolutePath);
+            if (types != null)
+                return types;
+
             // get the type from the manifest
-            var matchingEntries = manifest.FindAll(x => Path.GetFullPath(x.FilePath) == path);
+            var matchingEntries = manifest.FindAll(x => Path.GetFullPath(x.FilePath) == absolutePath);
 
             if (matchingEntries == null || matchingEntries.Count == 0)
                 return null;
 
-            var types = new List<string>();
+            types = new List<string>();
 
             foreach (var existingEntry in matchingEntries)
                 types.Add(existingEntry.Type);
 
-            typeCache[path] = types;
-            return typeCache[path];
+            var relativePath = GetRelativePath(absolutePath, GameDirectory);
+            typeCache[relativePath] = types;
+            return typeCache[relativePath];
+        }
+
+        internal static void TryAddTypeToCache(string absolutePath, string type)
+        {
+            var types = GetTypesFromCache(absolutePath);
+            if (types != null && types.Contains(type))
+                return;
+
+            if (types != null && !types.Contains(type))
+            {
+                types.Add(type);
+                return;
+            }
+
+            // add the new entry
+            typeCache[GetRelativePath(absolutePath, GameDirectory)] = new List<string> { type };
         }
 
         internal static Dictionary<string, DateTime> LoadOrCreateDBCache(string path)
@@ -718,9 +788,9 @@ namespace ModTek
             return;
         }
 
-        private static bool AddModEntryToDB(MetadataDatabase db, string path, string typeStr)
+        private static bool AddModEntryToDB(MetadataDatabase db, string absolutePath, string typeStr)
         {
-            if (Path.GetExtension(path)?.ToLower() != ".json")
+            if (Path.GetExtension(absolutePath)?.ToLower() != ".json")
                 return false;
 
             var type = (BattleTechResourceType)Enum.Parse(typeof(BattleTechResourceType), typeStr);
@@ -736,17 +806,26 @@ namespace ModTek
                 case BattleTechResourceType.MechDef:
                 case BattleTechResourceType.PilotDef:
                 case BattleTechResourceType.WeaponDef:
-                    if (!dbCache.ContainsKey(path) || dbCache[path] != File.GetLastWriteTimeUtc(path))
+                    var relativePath = GetRelativePath(absolutePath, GameDirectory);
+
+                    // had a previous to 0.5.0 absolute path in dbcache
+                    if (dbCache.ContainsKey(absolutePath))
+                    {
+                        dbCache[relativePath] = dbCache[absolutePath];
+                        dbCache.Remove(absolutePath);
+                    }
+
+                    if (!dbCache.ContainsKey(relativePath) || dbCache[relativePath] != File.GetLastWriteTimeUtc(absolutePath))
                     {
                         try
                         {
-                            VersionManifestHotReload.InstantiateResourceAndUpdateMDDB(type, path, db);
-                            dbCache[path] = File.GetLastWriteTimeUtc(path);
+                            VersionManifestHotReload.InstantiateResourceAndUpdateMDDB(type, absolutePath, db);
+                            dbCache[relativePath] = File.GetLastWriteTimeUtc(absolutePath);
                             return true;
                         }
                         catch (Exception e)
                         {
-                            Log($"\tAdd to DB failed for {Path.GetFileName(path)}, exception caught:");
+                            Log($"\tAdd to DB failed for {Path.GetFileName(absolutePath)}, exception caught:");
                             Log($"\t\t{e.Message}");
                             return false;
                         }
@@ -773,19 +852,6 @@ namespace ModTek
             }
 
             ProgressPanel.SubmitWork(NestedFunc);
-        }
-
-        internal static string ResolvePath(string path)
-        {
-            path = path.Replace("{{Mods}}", ModsDirectory);
-
-            if (!Path.IsPathRooted(path))
-            {
-                path = Path.Combine(StreamingAssetsDirectory, path);
-            }
-
-            var normalizedPath = Path.GetFullPath(path);
-            return normalizedPath;
         }
 
         internal static IEnumerator<ProgressReport> BuildCachedManifestLoop(VersionManifest manifest) {
@@ -837,7 +903,7 @@ namespace ModTek
 
                             // this assumes that .json can only have a single type
                             // typeCache will always contain this path
-                            modEntry.Type = typeCache[fakeStreamingAssetsPath][0];
+                            modEntry.Type = GetTypesFromCache(fakeStreamingAssetsPath)[0];
 
                             Log($"\t\tMerge => {modEntry.Id} ({modEntry.Type})");
 
@@ -870,7 +936,7 @@ namespace ModTek
                             continue;
                         case "AdvancedJSONMerge":
                             var targetFileRelative = AdvancedJSONMerger.GetTargetFile(modEntry.Path);
-                            var targetFile = ResolvePath(targetFileRelative);
+                            var targetFile = ResolvePath(targetFileRelative, StreamingAssetsDirectory);
 
                             // need to add the types of the file to the typeCache, so that they can be used later
                             // this actually returns the type, but we don't actually care about that right now
@@ -910,11 +976,7 @@ namespace ModTek
                         // this assumes that .json can only have a single type
                         modEntry.Type = matchingEntry.Type;
 
-                        if (!typeCache.ContainsKey(matchingPath))
-                        {
-                            typeCache[matchingPath] = new List<string>();
-                            typeCache[matchingPath].Add(modEntry.Type);
-                        }
+                        TryAddTypeToCache(matchingPath, modEntry.Type);
 
                         Log($"\t\tMerge => {modEntry.Id} ({modEntry.Type})");
 
@@ -935,10 +997,10 @@ namespace ModTek
             LogWithDate("Doing merges...");
             yield return new ProgressReport(0.0f, "Merges", "Doing Merges...");
             int mergeCount = 0;
-            foreach (var jsonMerge in jsonMerges)
+            foreach (var jsonMergeKVP in jsonMerges)
             {
-                yield return new ProgressReport((float)mergeCount++/jsonMerges.Count, "Merges", string.Format("Merging {0}", jsonMerge.Key));
-                var cachePath = jsonMergeCache.GetOrCreateCachedEntry(jsonMerge.Key, jsonMerge.Value);
+                yield return new ProgressReport((float)mergeCount++/jsonMerges.Count, "Merges", string.Format("Merging {0}", jsonMergeKVP.Key));
+                var cachePath = jsonMergeCache.GetOrCreateCachedEntry(jsonMergeKVP.Key, jsonMergeKVP.Value);
 
                 // something went wrong (the parent json prob had errors)
                 if (cachePath == null)
@@ -946,7 +1008,7 @@ namespace ModTek
 
                 var cacheEntry = new ModDef.ManifestEntry(cachePath);
                 cacheEntry.ShouldMergeJSON = false;
-                cacheEntry.Type = typeCache[jsonMerge.Key][0]; // this assumes only one type for each json file
+                cacheEntry.Type = GetTypesFromCache(jsonMergeKVP.Key)[0]; // this assumes only one type for each json file
                 cacheEntry.Id = InferIDFromFile(cachePath);
 
                 AddModEntry(manifest, cacheEntry);
@@ -966,11 +1028,10 @@ namespace ModTek
 
             string dbText = "Syncing Database";
             yield return new ProgressReport(0.0f, dbText, "");
-            foreach (var kvp in dbCache)
+            foreach (var path in dbCache.Keys)
             {
-                var path = kvp.Key;
-
-                if (File.Exists(path))
+                var absolutePath = ResolvePath(path, GameDirectory);
+                if (ManifestEntries.Exists(x => x.Path == absolutePath))
                     continue;
 
                 Log($"\tNeed to remove DB entry from file in path: {path}");
@@ -1042,7 +1103,7 @@ namespace ModTek
             stopwatch.Stop();
             Log("");
             LogWithDate($"Done. Elapsed running time: {stopwatch.Elapsed.TotalSeconds} seconds\n");
-          
+
             Logger.CloseStream();
             yield break;
         }


### PR DESCRIPTION
This will allow for users to move their directories and not have to rebuild ModTek caches. This might also allow for modpacks to contain pre-merged, pre-cached installs.