### PR TITLE
Change to a single direction conflict

### DIFF
--- a/ModTek/ModDef.cs
+++ b/ModTek/ModDef.cs
@@ -40,6 +40,9 @@ namespace ModTek
         public HashSet<string> ConflictsWith { get; set; } = new HashSet<string>();
         public HashSet<string> OptionallyDependsOn { get; set; } = new HashSet<string>();
 
+        [DefaultValue(true)]
+        public bool ShowFailedLoadPopup { get; set; } = true;
+
         // adding and running code
         public string DLL { get; set; }
         public string DLLEntryPoint { get; set; }

--- a/ModTek/ModDef.cs
+++ b/ModTek/ModDef.cs
@@ -2,6 +2,7 @@ using System;
 using System.Collections.Generic;
 using System.ComponentModel;
 using System.IO;
+using System.Linq;
 using Newtonsoft.Json;
 using Newtonsoft.Json.Linq;
 
@@ -64,6 +65,17 @@ namespace ModTek
             var modDef = JsonConvert.DeserializeObject<ModDef>(File.ReadAllText(path));
             modDef.Directory = Path.GetDirectoryName(path);
             return modDef;
+        }
+
+        public bool AreDependanciesResolved(List<string> loaded)
+        {
+            return DependsOn.Count == 0
+                || DependsOn.Intersect(loaded).Count() == DependsOn.Count;
+        }
+
+        public bool HasConflicts(List<string> otherMods)
+        {
+            return ConflictsWith.Intersect(otherMods).Any();
         }
     }
 }

--- a/ModTek/ModDef.cs
+++ b/ModTek/ModDef.cs
@@ -72,8 +72,7 @@ namespace ModTek
 
         public bool AreDependanciesResolved(List<string> loaded)
         {
-            return DependsOn.Count == 0
-                || DependsOn.Intersect(loaded).Count() == DependsOn.Count;
+            return DependsOn.Count == 0 || DependsOn.Intersect(loaded).Count() == DependsOn.Count;
         }
 
         public bool HasConflicts(List<string> otherMods)

--- a/ModTek/ModDef.cs
+++ b/ModTek/ModDef.cs
@@ -40,8 +40,8 @@ namespace ModTek
         public HashSet<string> ConflictsWith { get; set; } = new HashSet<string>();
         public HashSet<string> OptionallyDependsOn { get; set; } = new HashSet<string>();
 
-        [DefaultValue(true)]
-        public bool ShowFailedLoadPopup { get; set; } = true;
+        [DefaultValue(false)]
+        public bool IgnoreLoadFailure { get; set; } = false;
 
         // adding and running code
         public string DLL { get; set; }

--- a/ModTek/ModTek.cs
+++ b/ModTek/ModTek.cs
@@ -748,7 +748,7 @@ namespace ModTek
                 {
                     Log($"Will not load {modDef.Name} because it specifies a game version and this isn't it ({modDef.BattleTechVersion} vs. game {VersionInfo.ProductVersion})");
 
-                    if (modDef.IgnoreLoadFailure)
+                    if (!modDef.IgnoreLoadFailure)
                         FailedToLoadMods.Add(modDef.Name);
 
                     continue;
@@ -765,7 +765,7 @@ namespace ModTek
                         {
                             Log($"Will not load {modDef.Name} because it doesn't match the min version set in the mod.json ({modDef.BattleTechVersionMin} vs. game {VersionInfo.ProductVersion})");
 
-                            if (modDef.IgnoreLoadFailure)
+                            if (!modDef.IgnoreLoadFailure)
                                 FailedToLoadMods.Add(modDef.Name);
 
                             continue;
@@ -780,7 +780,7 @@ namespace ModTek
                         {
                             Log($"Will not load {modDef.Name} because it doesn't match the max version set in the mod.json ({modDef.BattleTechVersionMax} vs. game {VersionInfo.ProductVersion})");
 
-                            if (modDef.IgnoreLoadFailure)
+                            if (!modDef.IgnoreLoadFailure)
                                 FailedToLoadMods.Add(modDef.Name);
 
                             continue;
@@ -797,7 +797,7 @@ namespace ModTek
             {
                 Log($"Will not load {modName} because it's lacking a dependancy or has a conflict.");
 
-                if (modDefs[modName].IgnoreLoadFailure)
+                if (!modDefs[modName].IgnoreLoadFailure)
                     FailedToLoadMods.Add(modName);
             }
             Log("");
@@ -813,7 +813,7 @@ namespace ModTek
                 {
                     Log($"Skipping load of {modName} because one of its dependancies failed to load.");
 
-                    if (modDef.IgnoreLoadFailure)
+                    if (!modDef.IgnoreLoadFailure)
                         FailedToLoadMods.Add(modName);
 
                     continue;
@@ -823,14 +823,14 @@ namespace ModTek
 
                 try
                 {
-                    if (!LoadMod(modDef) && modDef.IgnoreLoadFailure)
+                    if (!LoadMod(modDef) && !modDef.IgnoreLoadFailure)
                         FailedToLoadMods.Add(modName);
                 }
                 catch (Exception e)
                 {
                     LogException($"Tried to load mod: {modDef.Name}, but something went wrong. Make sure all of your JSON is correct!", e);
 
-                    if (modDef.IgnoreLoadFailure)
+                    if (!modDef.IgnoreLoadFailure)
                         FailedToLoadMods.Add(modName);
                 }
             }

--- a/ModTek/ModTek.cs
+++ b/ModTek/ModTek.cs
@@ -534,8 +534,7 @@ namespace ModTek
             // load the order specified in the file
             foreach (var modName in cachedOrder)
             {
-                if (!modDefsCopy.ContainsKey(modName)
-                    || !modDefsCopy[modName].AreDependanciesResolved(loadOrder))
+                if (!modDefsCopy.ContainsKey(modName) || !modDefsCopy[modName].AreDependanciesResolved(loadOrder))
                     continue;
 
                 modDefsCopy.Remove(modName);
@@ -599,7 +598,10 @@ namespace ModTek
                     }
 
                     modEntry.Id = Path.GetFileNameWithoutExtension(modEntry.Path);
-                    if (!FileIsOnDenyList(modEntry.Path)) potentialAdditions.Add(modEntry);
+
+                    if (!FileIsOnDenyList(modEntry.Path))
+                        potentialAdditions.Add(modEntry);
+
                     continue;
                 }
 
@@ -746,10 +748,11 @@ namespace ModTek
                 // check game version vs. specific version or against min/max
                 if (!string.IsNullOrEmpty(modDef.BattleTechVersion) && !VersionInfo.ProductVersion.StartsWith(modDef.BattleTechVersion))
                 {
-                    Log($"Will not load {modDef.Name} because it specifies a game version and this isn't it ({modDef.BattleTechVersion} vs. game {VersionInfo.ProductVersion})");
-
                     if (!modDef.IgnoreLoadFailure)
+                    {
+                        Log($"Will not load {modDef.Name} because it specifies a game version and this isn't it ({modDef.BattleTechVersion} vs. game {VersionInfo.ProductVersion})");
                         FailedToLoadMods.Add(modDef.Name);
+                    }
 
                     continue;
                 }
@@ -763,10 +766,11 @@ namespace ModTek
 
                         if (btgVersion < minVersion)
                         {
-                            Log($"Will not load {modDef.Name} because it doesn't match the min version set in the mod.json ({modDef.BattleTechVersionMin} vs. game {VersionInfo.ProductVersion})");
-
                             if (!modDef.IgnoreLoadFailure)
+                            {
+                                Log($"Will not load {modDef.Name} because it doesn't match the min version set in the mod.json ({modDef.BattleTechVersionMin} vs. game {VersionInfo.ProductVersion})");
                                 FailedToLoadMods.Add(modDef.Name);
+                            }
 
                             continue;
                         }
@@ -778,10 +782,11 @@ namespace ModTek
 
                         if (btgVersion > maxVersion)
                         {
-                            Log($"Will not load {modDef.Name} because it doesn't match the max version set in the mod.json ({modDef.BattleTechVersionMax} vs. game {VersionInfo.ProductVersion})");
-
                             if (!modDef.IgnoreLoadFailure)
+                            {
+                                Log($"Will not load {modDef.Name} because it doesn't match the max version set in the mod.json ({modDef.BattleTechVersionMax} vs. game {VersionInfo.ProductVersion})");
                                 FailedToLoadMods.Add(modDef.Name);
+                            }
 
                             continue;
                         }
@@ -795,10 +800,11 @@ namespace ModTek
             modLoadOrder = GetLoadOrder(modDefs, out var willNotLoad);
             foreach (var modName in willNotLoad)
             {
-                Log($"Will not load {modName} because it's lacking a dependancy or has a conflict.");
-
                 if (!modDefs[modName].IgnoreLoadFailure)
+                {
+                    Log($"Will not load {modName} because it's lacking a dependancy or has a conflict.");
                     FailedToLoadMods.Add(modName);
+                }
             }
             Log("");
 
@@ -811,10 +817,11 @@ namespace ModTek
 
                 if (modDef.DependsOn.Intersect(FailedToLoadMods).Count() > 0)
                 {
-                    Log($"Skipping load of {modName} because one of its dependancies failed to load.");
-
                     if (!modDef.IgnoreLoadFailure)
+                    {
+                        Log($"Skipping load of {modName} because one of its dependancies failed to load.");
                         FailedToLoadMods.Add(modName);
+                    }
 
                     continue;
                 }
@@ -828,10 +835,11 @@ namespace ModTek
                 }
                 catch (Exception e)
                 {
-                    LogException($"Tried to load mod: {modDef.Name}, but something went wrong. Make sure all of your JSON is correct!", e);
-
                     if (!modDef.IgnoreLoadFailure)
+                    {
+                        LogException($"Tried to load mod: {modDef.Name}, but something went wrong. Make sure all of your JSON is correct!", e);
                         FailedToLoadMods.Add(modName);
+                    }
                 }
             }
 

--- a/ModTek/ModTek.cs
+++ b/ModTek/ModTek.cs
@@ -748,7 +748,7 @@ namespace ModTek
                 {
                     Log($"Will not load {modDef.Name} because it specifies a game version and this isn't it ({modDef.BattleTechVersion} vs. game {VersionInfo.ProductVersion})");
 
-                    if (modDef.ShowFailedLoadPopup)
+                    if (modDef.IgnoreLoadFailure)
                         FailedToLoadMods.Add(modDef.Name);
 
                     continue;
@@ -765,7 +765,7 @@ namespace ModTek
                         {
                             Log($"Will not load {modDef.Name} because it doesn't match the min version set in the mod.json ({modDef.BattleTechVersionMin} vs. game {VersionInfo.ProductVersion})");
 
-                            if (modDef.ShowFailedLoadPopup)
+                            if (modDef.IgnoreLoadFailure)
                                 FailedToLoadMods.Add(modDef.Name);
 
                             continue;
@@ -780,7 +780,7 @@ namespace ModTek
                         {
                             Log($"Will not load {modDef.Name} because it doesn't match the max version set in the mod.json ({modDef.BattleTechVersionMax} vs. game {VersionInfo.ProductVersion})");
 
-                            if (modDef.ShowFailedLoadPopup)
+                            if (modDef.IgnoreLoadFailure)
                                 FailedToLoadMods.Add(modDef.Name);
 
                             continue;
@@ -797,7 +797,7 @@ namespace ModTek
             {
                 Log($"Will not load {modName} because it's lacking a dependancy or has a conflict.");
 
-                if (modDefs[modName].ShowFailedLoadPopup)
+                if (modDefs[modName].IgnoreLoadFailure)
                     FailedToLoadMods.Add(modName);
             }
             Log("");
@@ -813,7 +813,7 @@ namespace ModTek
                 {
                     Log($"Skipping load of {modName} because one of its dependancies failed to load.");
 
-                    if (modDef.ShowFailedLoadPopup)
+                    if (modDef.IgnoreLoadFailure)
                         FailedToLoadMods.Add(modName);
 
                     continue;
@@ -823,14 +823,14 @@ namespace ModTek
 
                 try
                 {
-                    if (!LoadMod(modDef) && modDef.ShowFailedLoadPopup)
+                    if (!LoadMod(modDef) && modDef.IgnoreLoadFailure)
                         FailedToLoadMods.Add(modName);
                 }
                 catch (Exception e)
                 {
                     LogException($"Tried to load mod: {modDef.Name}, but something went wrong. Make sure all of your JSON is correct!", e);
 
-                    if (modDef.ShowFailedLoadPopup)
+                    if (modDef.IgnoreLoadFailure)
                         FailedToLoadMods.Add(modName);
                 }
             }

--- a/ModTek/ModTek.cs
+++ b/ModTek/ModTek.cs
@@ -747,7 +747,10 @@ namespace ModTek
                 if (!string.IsNullOrEmpty(modDef.BattleTechVersion) && !VersionInfo.ProductVersion.StartsWith(modDef.BattleTechVersion))
                 {
                     Log($"Will not load {modDef.Name} because it specifies a game version and this isn't it ({modDef.BattleTechVersion} vs. game {VersionInfo.ProductVersion})");
-                    FailedToLoadMods.Add(modDef.Name);
+
+                    if (modDef.ShowFailedLoadPopup)
+                        FailedToLoadMods.Add(modDef.Name);
+
                     continue;
                 }
                 else
@@ -761,7 +764,10 @@ namespace ModTek
                         if (btgVersion < minVersion)
                         {
                             Log($"Will not load {modDef.Name} because it doesn't match the min version set in the mod.json ({modDef.BattleTechVersionMin} vs. game {VersionInfo.ProductVersion})");
-                            FailedToLoadMods.Add(modDef.Name);
+
+                            if (modDef.ShowFailedLoadPopup)
+                                FailedToLoadMods.Add(modDef.Name);
+
                             continue;
                         }
                     }
@@ -773,7 +779,10 @@ namespace ModTek
                         if (btgVersion > maxVersion)
                         {
                             Log($"Will not load {modDef.Name} because it doesn't match the max version set in the mod.json ({modDef.BattleTechVersionMax} vs. game {VersionInfo.ProductVersion})");
-                            FailedToLoadMods.Add(modDef.Name);
+
+                            if (modDef.ShowFailedLoadPopup)
+                                FailedToLoadMods.Add(modDef.Name);
+
                             continue;
                         }
                     }
@@ -787,7 +796,9 @@ namespace ModTek
             foreach (var modName in willNotLoad)
             {
                 Log($"Will not load {modName} because it's lacking a dependancy or has a conflict.");
-                FailedToLoadMods.Add(modName);
+
+                if (modDefs[modName].ShowFailedLoadPopup)
+                    FailedToLoadMods.Add(modName);
             }
             Log("");
 
@@ -801,7 +812,10 @@ namespace ModTek
                 if (modDef.DependsOn.Intersect(FailedToLoadMods).Count() > 0)
                 {
                     Log($"Skipping load of {modName} because one of its dependancies failed to load.");
-                    FailedToLoadMods.Add(modName);
+
+                    if (modDef.ShowFailedLoadPopup)
+                        FailedToLoadMods.Add(modName);
+
                     continue;
                 }
 
@@ -809,13 +823,15 @@ namespace ModTek
 
                 try
                 {
-                    if (!LoadMod(modDef))
+                    if (!LoadMod(modDef) && modDef.ShowFailedLoadPopup)
                         FailedToLoadMods.Add(modName);
                 }
                 catch (Exception e)
                 {
                     LogException($"Tried to load mod: {modDef.Name}, but something went wrong. Make sure all of your JSON is correct!", e);
-                    FailedToLoadMods.Add(modName);
+
+                    if (modDef.ShowFailedLoadPopup)
+                        FailedToLoadMods.Add(modName);
                 }
             }
 

--- a/ModTek/Patches/MainMenu.cs
+++ b/ModTek/Patches/MainMenu.cs
@@ -15,7 +15,7 @@ namespace ModTek
             if (ModTek.FailedToLoadMods.Count > 0)
             {
                 GenericPopupBuilder.Create("Some Mods Didn't Load",
-                    $"These mods had something go wrong\nCheck \"{ModTek.GetRelativePath(Logger.LogPath, ModTek.GameDirectory)}\" for more info\n\n"
+                    $"Check \"{ModTek.GetRelativePath(Logger.LogPath, ModTek.GameDirectory)}\" for more info\n\n"
                         + string.Join(", ", ModTek.FailedToLoadMods.ToArray()))
                     .AddButton("Continue", null, true, null)
                     .Render();


### PR DESCRIPTION
This moves a couple things to the ModDef class and makes it so that any mod that has conflicts doesn't load if we would even attempt to load a conflict instead of making conflicts bi-directional and loading only the first one.

Fixes #109 