### PR TITLE
Added EnableAssemblyVersionCheck, closes #113 .

### DIFF
--- a/ModTek/ModDef.cs
+++ b/ModTek/ModDef.cs
@@ -52,6 +52,9 @@ namespace ModTek
         public string DLL { get; set; }
         public string DLLEntryPoint { get; set; }
 
+        [DefaultValue(false)]
+        public bool EnableAssemblyVersionCheck { get; set; } = false;
+
         // changing implicit loading behavior
         [DefaultValue(true)]
         public bool LoadImplicitManifest { get; set; } = true;


### PR DESCRIPTION
requires https://github.com/BattletechModders/BattleTechModLoader/pull/34

didn't do the FailedToLoadMods changes