### PR TITLE
potential fix for player emblems 

### DIFF
--- a/ModTek/Patches/UIManagerPatches.cs
+++ b/ModTek/Patches/UIManagerPatches.cs
@@ -3,6 +3,7 @@ using BattleTech.UI;
 using Harmony;
 using HBS;
 using ModTek.RuntimeLog;
+using BattleTech;
 
 namespace ModTek.Patches
 {
@@ -25,6 +26,9 @@ namespace ModTek.Patches
         public static void Prefix()
         {
             DataManager dm = SceneSingletonBehavior<DataManagerUnityInstance>.Instance.DataManager;
+            RLog.LogWrite("Forcing refresh of BTRL Manifest...");
+            Traverse.Create(dm.ResourceLocator).Property("manifest").SetValue(VersionManifestUtilities.LoadDefaultManifest());
+            RLog.LogWrite(" DONE");
             Traverse refreshTypedEntriesT = Traverse.Create(dm.ResourceLocator).Method("RefreshTypedEntries");
             RLog.LogWrite("Forcing refresh of TypedEntities to prevent Shadowhawk DLC bug...");
             refreshTypedEntriesT.GetValue();

--- a/ModTek/Properties/AssemblyInfo.cs
+++ b/ModTek/Properties/AssemblyInfo.cs
@@ -30,4 +30,4 @@ using System.Runtime.InteropServices;
 //
 // You can specify all the values or you can default the Build and Revision Numbers
 // by using the '*' as shown below:
-[assembly: AssemblyVersion("0.7.7.3")]
+[assembly: AssemblyVersion("0.7.7.4")]


### PR DESCRIPTION
potentially fixes Resource locator patch by forcing its manifest to be the cached manifest from modtek