### PR TITLE
VersionManifestAddendum caching, runtime log debug flag

### DIFF
--- a/ModTek/Configuration.cs
+++ b/ModTek/Configuration.cs
@@ -29,10 +29,10 @@ namespace ModTek
 
             try
             {
-                var config = JsonConvert.DeserializeObject<Configuration>(File.ReadAllText(path),
+                var text = File.ReadAllText(path);
+                var config = JsonConvert.DeserializeObject<Configuration>(text,
                     new JsonSerializerSettings { ObjectCreationHandling = ObjectCreationHandling.Replace });
-                Logger.Log($"Loaded config.");
-
+                Logger.Log($"Loaded config from path: {path}");
                 return config;
             }
             catch (Exception e)
@@ -40,6 +40,13 @@ namespace ModTek
                 Logger.LogException("Reading configuration failed -- will rebuild it!", e);
                 return new Configuration();
             }
+        }
+
+        public override string ToString()
+        {
+            return $"ShowLoadingScreenErrors: {this.ShowLoadingScreenErrors}  ShowErrorPopup: {this.ShowErrorPopup}  " +
+                $"EnableDebugLogging: {this.EnableDebugLogging}  UseErrorWhiteList: {this.UseErrorWhiteList}  " +
+                $"ErrorWhiteList: {String.Join("','", this.ErrorWhitelist)}";
         }
     }
 }

--- a/ModTek/Configuration.cs
+++ b/ModTek/Configuration.cs
@@ -12,6 +12,7 @@ namespace ModTek
         public bool ShowErrorPopup = true;
         public bool UseErrorWhiteList = true;
         public List<string> ErrorWhitelist = new List<string> { "Data.DataManager [ERROR] ManifestEntry is null" };
+        public bool EnableDebugLogging = true;
 
         public void ToFile(string path)
         {

--- a/ModTek/ModTek.cs
+++ b/ModTek/ModTek.cs
@@ -162,7 +162,7 @@ namespace ModTek
             TypeCachePath = Path.Combine(CacheDirectory, TYPE_CACHE_FILE_NAME);
             ModMDDBPath = Path.Combine(DatabaseDirectory, MDD_FILE_NAME);
             DBCachePath = Path.Combine(DatabaseDirectory, DB_CACHE_FILE_NAME);
-            ConfigPath = Path.Combine(TempModTekDirectory, CONFIG_FILE_NAME);
+            ConfigPath = Path.Combine(ModTekDirectory, CONFIG_FILE_NAME);
             ModTekSettingsPath = Path.Combine(ModTekDirectory, MOD_JSON_NAME);
 
             // creates the directories above it as well

--- a/ModTek/ModTek.cs
+++ b/ModTek/ModTek.cs
@@ -1554,6 +1554,7 @@ namespace ModTek
 
             Finish();
         }
+
         public static bool LoadDataAddendum(DataAddendumEntry dataAddendumEntry, string modDefDirectory)
         {
             try

--- a/ModTek/ModTek.csproj
+++ b/ModTek/ModTek.csproj
@@ -85,6 +85,7 @@
     <Compile Include="Patches\SoundBanks.cs" />
     <Compile Include="Patches\SVGAssetHelper.cs" />
     <Compile Include="Patches\UIManagerPatches.cs" />
+    <Compile Include="Patches\VersionManifestAddendum.cs" />
     <Compile Include="Util\AssemblyUtil.cs" />
     <Compile Include="Util\JSONMerger.cs" />
     <Compile Include="Configuration.cs" />

--- a/ModTek/Patches/BattleTechResourceLocator.cs
+++ b/ModTek/Patches/BattleTechResourceLocator.cs
@@ -204,7 +204,6 @@ namespace ModTek.Patches
             sw.Stop();
 
             __state.Stop();
-
             if (ModTek.Config.EnableDebugLogging)
                 RLog.M.TWL(0, $"BattleTechResourceLocator.RefreshTypedEntries complete in {__state.ElapsedMilliseconds}ms");
         }

--- a/ModTek/Patches/BattleTechResourceLocator.cs
+++ b/ModTek/Patches/BattleTechResourceLocator.cs
@@ -1,5 +1,6 @@
 using System;
 using System.Collections.Generic;
+using System.Diagnostics;
 using System.Globalization;
 using System.Linq;
 using System.Reflection;
@@ -20,10 +21,14 @@ namespace ModTek.Patches
 
         public static void Postfix(BattleTechResourceLocator __instance, BattleTechResourceType type, VersionManifestAddendum addendum, ref VersionManifestEntry[] __result)
         {
-            RLog.M.TWL(0, "BattleTechResourceLocator.AllEntriesOfResourceFromAddendum "+addendum.Name+" type:"+type);
-            RLog.M.TWL(0, "BattleTechResourceLocator.AllEntriesOfResourceFromAddendum " + addendum.Name + " type:" + type);
-            foreach (VersionManifestEntry entry in __result) {
-                RLog.M.WL(1,entry.FileName);
+            if (ModTek.Config.EnableDebugLogging)
+            {
+                RLog.M.TWL(0, "BattleTechResourceLocator.AllEntriesOfResourceFromAddendum " + addendum.Name + " type:" + type);
+                RLog.M.TWL(0, "BattleTechResourceLocator.AllEntriesOfResourceFromAddendum " + addendum.Name + " type:" + type);
+                foreach (VersionManifestEntry entry in __result)
+                {
+                    RLog.M.WL(1, entry.FileName);
+                }
             }
         }
     }
@@ -31,34 +36,7 @@ namespace ModTek.Patches
     public static class BattleTechResourceLocator_EntryByID_Patch
     {
         private static Dictionary<BattleTechResourceType, Dictionary<string, VersionManifestEntry>> modtekManifest = new Dictionary<BattleTechResourceType, Dictionary<string, VersionManifestEntry>>();
-        public static void AddToModTekManifest(this VersionManifestEntry versionManifestEntry, BattleTechResourceType resourceType)
-        {
-            return;
-            //Dictionary<string, VersionManifestEntry> manifests = null;
-            //if (!modtekManifest.TryGetValue(resourceType, out manifests))
-            //{
-            //    manifests = new Dictionary<string, VersionManifestEntry>();
-            //    modtekManifest.Add(resourceType, manifests);
-            //}
-            //string id = versionManifestEntry.Id.ToUpper(CultureInfo.InvariantCulture);
-            //if (manifests.ContainsKey(id))
-            //{
-            //    modtekManifest[resourceType][id] = versionManifestEntry;
-            //}
-            //else
-            //{
-            //    manifests.Add(id, versionManifestEntry);
-            //}
-        }
-        public static void RemoveFromModTekManifest(this VersionManifestEntry entry, BattleTechResourceType type)
-        {
-            return;
-            //if (modtekManifest.TryGetValue(type, out Dictionary<string, VersionManifestEntry> manifests))
-            //{
-            //    string id = entry.Id.ToUpper(CultureInfo.InvariantCulture);
-            //    manifests.Remove(id);
-            //}
-        }
+
         public static bool Prepare() { return false; }
         public static void Postfix(string id, BattleTechResourceType type, bool filterByOwnership, ref VersionManifestEntry __result)
         {
@@ -94,29 +72,45 @@ namespace ModTek.Patches
     public static class BattleTechResourceLocator_RefreshTypedEntries_Patch
     {
         public static bool Prepare() { return ModTek.Enabled; }
+
         private static PropertyInfo f_manifest = typeof(BattleTechResourceLocator).GetProperty("manifest", BindingFlags.Instance|BindingFlags.NonPublic);
         private static VersionManifest manifest(this BattleTechResourceLocator locator) { return (VersionManifest)f_manifest.GetValue(locator); }
         private static void manifest(this BattleTechResourceLocator locator, VersionManifest manifest) { f_manifest.SetValue(locator, manifest); }
-        public static void Prefix(BattleTechResourceLocator __instance)
+        public static void Prefix(BattleTechResourceLocator __instance, ref Stopwatch __state, int ___typedEntriesCount)
         {
-            RLog.M.TWL(0, "BattleTechResourceLocator.RefreshTypedEntries");
+            __state = new Stopwatch();
+            __state.Start();
+
             VersionManifest versionManifest = __instance.manifest();
+            if (ModTek.Config.EnableDebugLogging)
+            {
+                RLog.M.TWL(0, "BattleTechResourceLocator.RefreshTypedEntries");
+                RLog.M.TWL(0, $"  typedEntriesCount: {___typedEntriesCount}  versionManifest.Count: {versionManifest.Count}");
+                RLog.M.TWL(0, $"  addBTRLEntries: {ModTek.AddBTRLEntries.Count}  removeBTRLEntries: {ModTek.RemoveBTRLEntries.Count}");
+            }
+
+            
             if (versionManifest != ModTek.CachedVersionManifest)
             {
                 RLog.M.TWL(0, "WARNING! STRANGE BEHAVIOR cachedManifest does not much locator manifest. Resolving");
                 __instance.manifest(ModTek.CachedVersionManifest);
             }
         }
+
         public static void Postfix(BattleTechResourceLocator __instance, ContentPackIndex ___contentPackIndex,
             ref Dictionary<BattleTechResourceType, Dictionary<string, VersionManifestEntry>> ___baseManifest,
             ref Dictionary<BattleTechResourceType, Dictionary<string, VersionManifestEntry>> ___contentPacksManifest,
-            ref Dictionary<VersionManifestAddendum, Dictionary<BattleTechResourceType, Dictionary<string, VersionManifestEntry>>> ___addendumsManifest)
+            ref Dictionary<VersionManifestAddendum, Dictionary<BattleTechResourceType, Dictionary<string, VersionManifestEntry>>> ___addendumsManifest,
+            Stopwatch __state)
         {
+
+            Stopwatch sw = new Stopwatch();
+            sw.Start();
             foreach (var entry in ModTek.AddBTRLEntries)
             {
                 var versionManifestEntry = entry.GetVersionManifestEntry();
                 var resourceType = (BattleTechResourceType)Enum.Parse(typeof(BattleTechResourceType), entry.Type);
-                versionManifestEntry.AddToModTekManifest(resourceType);
+                // versionManifestEntry.AddToModTekManifest(resourceType); THIS WAS A NOP
 
                 if (___contentPackIndex == null || ___contentPackIndex.IsResourceOwned(versionManifestEntry.Id))
                 {
@@ -136,7 +130,8 @@ namespace ModTek.Patches
                         manifests.Add(versionManifestEntry.Id, versionManifestEntry);
                     }
                     
-                    RLog.M.WL(1, "baseManifest add:"+resourceType+" "+entry.Id+" "+ (versionManifestEntry == null?"null": versionManifestEntry.FilePath));
+                    if (ModTek.Config.EnableDebugLogging)
+                        RLog.M.WL(1, "baseManifest add:"+resourceType+" "+entry.Id+" "+ (versionManifestEntry == null?"null": versionManifestEntry.FilePath));
                 }
                 else
                 {
@@ -145,7 +140,8 @@ namespace ModTek.Patches
                         ___contentPacksManifest.Add(resourceType, new Dictionary<string, VersionManifestEntry>());
 
                     ___contentPacksManifest[resourceType][entry.Id] = versionManifestEntry;
-                    RLog.M.WL(1, "contentPacksManifest add:" + resourceType + " " + entry.Id);
+                    if (ModTek.Config.EnableDebugLogging)
+                        RLog.M.WL(1, "contentPacksManifest add:" + resourceType + " " + entry.Id);
                 }
 
                 if (string.IsNullOrEmpty(entry.AddToAddendum))
@@ -158,21 +154,26 @@ namespace ModTek.Patches
                 {
                     if (!___addendumsManifest.ContainsKey(addendum))
                     {
-                        RLog.M.WL(1, "adding new enum:"+addendum.Name);
+                        if (ModTek.Config.EnableDebugLogging)
+                            RLog.M.WL(1, "adding new enum:"+addendum.Name);
                         ___addendumsManifest.Add(addendum, new Dictionary<BattleTechResourceType, Dictionary<string, VersionManifestEntry>>());
                     }
                     if (!___addendumsManifest[addendum].ContainsKey(resourceType))
                         ___addendumsManifest[addendum].Add(resourceType, new Dictionary<string, VersionManifestEntry>());
 
                     ___addendumsManifest[addendum][resourceType][entry.Id] = versionManifestEntry;
-                    RLog.M.WL(1, "addendumsManifest[" + addendum.Name + "]["+resourceType+"]["+entry.Id+"] " + versionManifestEntry.FilePath);
+                    if (ModTek.Config.EnableDebugLogging)
+                        RLog.M.WL(1, "addendumsManifest[" + addendum.Name + "]["+resourceType+"]["+entry.Id+"] " + versionManifestEntry.FilePath);
                 }
             }
+            sw.Stop();
+            //RLog.M.WL(0, $"BTRL ADD took: {sw.ElapsedMilliseconds}ms");
 
+            sw.Restart();
             foreach (var entry in ModTek.RemoveBTRLEntries)
             {
                 var resourceType = (BattleTechResourceType)Enum.Parse(typeof(BattleTechResourceType), entry.Type);
-                entry.RemoveFromModTekManifest(resourceType);
+                // entry.RemoveFromModTekManifest(resourceType); THIS WAS A NOP
 
                 if (___baseManifest.ContainsKey(resourceType) && ___baseManifest[resourceType].ContainsKey(entry.Id))
                 {
@@ -193,6 +194,12 @@ namespace ModTek.Patches
                     containingAddendum.Value[resourceType].Remove(entry.Id);
                 }
             }
+            sw.Stop();
+
+            __state.Stop();
+
+            if (ModTek.Config.EnableDebugLogging)
+                RLog.M.TWL(0, $"BattleTechResourceLocator.RefreshTypedEntries complete in {__state.ElapsedMilliseconds}ms");
         }
     }
 }

--- a/ModTek/Patches/BattleTechResourceLocator.cs
+++ b/ModTek/Patches/BattleTechResourceLocator.cs
@@ -162,6 +162,10 @@ namespace ModTek.Patches
                         ___addendumsManifest[addendum].Add(resourceType, new Dictionary<string, VersionManifestEntry>());
 
                     ___addendumsManifest[addendum][resourceType][entry.Id] = versionManifestEntry;
+
+                    // Invalidate the cache we've created for this addendum
+                    VersionManifestAddendumCache.InvalidateAddendum(addendum);
+
                     if (ModTek.Config.EnableDebugLogging)
                         RLog.M.WL(1, "addendumsManifest[" + addendum.Name + "]["+resourceType+"]["+entry.Id+"] " + versionManifestEntry.FilePath);
                 }
@@ -192,6 +196,9 @@ namespace ModTek.Patches
                 {
                     RLog.M.WL(1, "remove addendumsManifest[" + resourceType + "][" + entry.Id + "]");
                     containingAddendum.Value[resourceType].Remove(entry.Id);
+
+                    // Invalidate the cache we've created for this addendum
+                    VersionManifestAddendumCache.InvalidateAddendum(containingAddendum.Key);
                 }
             }
             sw.Stop();

--- a/ModTek/Patches/SimGameConstants.cs
+++ b/ModTek/Patches/SimGameConstants.cs
@@ -9,7 +9,8 @@ namespace ModTek
     [HarmonyPatch(MethodType.Normal)]
     public static class SimGameConstants_FromJSON
     {
-        public static bool Prepare() { return ModTek.Enabled; }
+        public static bool Prepare() => ModTek.Enabled && ModTek.Config.EnableDebugLogging;
+
         public static void Postfix(SimGameConstants __instance, string json)
         {
             RLog.M.TWL(0, "SimGameConstants.FromJSON");

--- a/ModTek/Patches/UIManagerPatches.cs
+++ b/ModTek/Patches/UIManagerPatches.cs
@@ -26,13 +26,18 @@ namespace ModTek.Patches
         public static void Prefix()
         {
             DataManager dm = SceneSingletonBehavior<DataManagerUnityInstance>.Instance.DataManager;
-            RLog.LogWrite("Forcing refresh of BTRL Manifest...");
+
+            Stopwatch sw = new Stopwatch();
+            sw.Start();
+            RLog.LogWrite("Forcing refresh of BTRL Manifest...\n");
             Traverse.Create(dm.ResourceLocator).Property("manifest").SetValue(VersionManifestUtilities.LoadDefaultManifest());
-            RLog.LogWrite(" DONE");
+            RLog.LogWrite($"Refresh of BTRL manifest complete in {sw.ElapsedMilliSeconds}ms \n");
+
+            sw.Restart();
             Traverse refreshTypedEntriesT = Traverse.Create(dm.ResourceLocator).Method("RefreshTypedEntries");
-            RLog.LogWrite("Forcing refresh of TypedEntities to prevent Shadowhawk DLC bug...");
+            RLog.LogWrite("Forcing refresh of TypedEntities to prevent Shadowhawk DLC bug...\n");
             refreshTypedEntriesT.GetValue();
-            RLog.LogWrite(" DONE");
+            RLog.LogWrite($"Forced refresh of TypedEntities complete in {sw.ElapsedMilliSeconds}ms\n");
         }
     }
 }

--- a/ModTek/Patches/UIManagerPatches.cs
+++ b/ModTek/Patches/UIManagerPatches.cs
@@ -27,17 +27,28 @@ namespace ModTek.Patches
         {
             DataManager dm = SceneSingletonBehavior<DataManagerUnityInstance>.Instance.DataManager;
 
+
             Stopwatch sw = new Stopwatch();
             sw.Start();
-            RLog.LogWrite("Forcing refresh of BTRL Manifest...\n");
+            if (ModTek.Config.EnableDebugLogging)
+                RLog.LogWrite("Forcing refresh of BTRL Manifest...\n");
+
             Traverse.Create(dm.ResourceLocator).Property("manifest").SetValue(VersionManifestUtilities.LoadDefaultManifest());
-            RLog.LogWrite($"Refresh of BTRL manifest complete in {sw.ElapsedMilliSeconds}ms \n");
+
+            sw.Stop();
+            if (ModTek.Config.EnableDebugLogging)
+                RLog.LogWrite($"Refresh of BTRL manifest complete in {sw.ElapsedMilliSeconds}ms \n");
 
             sw.Restart();
+            if (ModTek.Config.EnableDebugLogging)
+                RLog.LogWrite("Forcing refresh of TypedEntities to prevent Shadowhawk DLC bug...\n");
+
             Traverse refreshTypedEntriesT = Traverse.Create(dm.ResourceLocator).Method("RefreshTypedEntries");
-            RLog.LogWrite("Forcing refresh of TypedEntities to prevent Shadowhawk DLC bug...\n");
             refreshTypedEntriesT.GetValue();
-            RLog.LogWrite($"Forced refresh of TypedEntities complete in {sw.ElapsedMilliSeconds}ms\n");
+
+            sw.Stop();
+            if (ModTek.Config.EnableDebugLogging)
+                RLog.LogWrite($"Forced refresh of TypedEntities complete in {sw.ElapsedMilliSeconds}ms\n");
         }
     }
 }

--- a/ModTek/Patches/VersionManifestAddendum.cs
+++ b/ModTek/Patches/VersionManifestAddendum.cs
@@ -1,0 +1,109 @@
+using BattleTech;
+using Harmony;
+using ModTek.RuntimeLog;
+using System;
+using System.Collections.Generic;
+using System.Reflection;
+
+// ReSharper disable InconsistentNaming
+// ReSharper disable UnusedMember.Global
+
+namespace ModTek.Patches
+{
+    /// <summary>
+    /// Patch the LoadDefaultManifest to use the cached manifest that is built at ModTek load instead of rebuilding it
+    /// This is primarily a performance optimization
+    /// </summary>
+    [HarmonyPatch(typeof(VersionManifest), "GetAddendumContainingEntry")]
+    [HarmonyPatch(new Type[] { typeof(string), typeof(string) })]
+    static class VersionManifest_GetAddendumContainingEntry
+    {
+
+        static bool Prepare() => ModTek.Enabled;
+
+        static bool Prefix(string id, string type, ref VersionManifestAddendum __result, List<VersionManifestAddendum> ___addendums)
+        {
+            VersionManifestAddendum queryValue;
+            if (!VersionManifestAddendumCache.FindInCache(id, type, out queryValue))
+            {
+                queryValue = VersionManifestAddendumCache.FindInAddendums(id, type, ___addendums);
+            }
+
+            __result = queryValue;
+            return false;
+        }
+    }
+
+    [HarmonyPatch(typeof(VersionManifest), "GetAddendumContainingEntry")]
+    static class VersionManifest_GetAddendumContainingEntry_VME
+    {
+
+        // Necessary as VersionManifestEntry is out - ergo a ref, and can't be defined in an attribute
+        static MethodBase TargetMethod(HarmonyInstance instance)
+        {
+            MethodInfo type = AccessTools.Method(typeof(VersionManifest), "GetAddendumContainingEntry",
+                new Type[] { typeof(string), typeof(string), typeof(VersionManifestEntry).MakeByRefType() });
+            return type;
+        }
+
+        static bool Prepare() => ModTek.Enabled;
+
+        static bool Prefix(string id, string type, out VersionManifestEntry entry, ref VersionManifestAddendum __result,
+            List<VersionManifestAddendum> ___addendums)
+        {
+            VersionManifestAddendum queryValue;
+            if (!VersionManifestAddendumCache.FindInCache(id, type, out queryValue))
+            {
+                queryValue = VersionManifestAddendumCache.FindInAddendums(id, type, ___addendums);
+            }
+
+            entry = queryValue.Get(id, type);
+            __result = queryValue;
+            return false;
+        }
+    }
+
+    static class VersionManifestAddendumCache
+    {
+        private static Dictionary<string, VersionManifestAddendum> lookupCache = new Dictionary<string, VersionManifestAddendum>();
+
+        private static Dictionary<string, int> cachedAddendums = new Dictionary<string, int>();
+
+        private static void UpdateCache(List<VersionManifestAddendum> addendums)
+        {
+            foreach (VersionManifestAddendum vma in addendums)
+            {
+                if (!cachedAddendums.ContainsKey(vma.Name))
+                {
+                    RLog.LogWrite($"Adding to addendum cache: {vma.Name}\n");
+                    foreach (VersionManifestEntry vme in vma.Entries)
+                    {
+                        string entryKey = $"{vme.Id}_{vme.Type}";
+                        if (!lookupCache.ContainsKey(entryKey))
+                            lookupCache.Add(entryKey, vma);
+                    }
+
+                    cachedAddendums.Add(vma.Name, 0);
+                }
+            }
+        }
+
+        public static bool FindInCache(string id, string type, out VersionManifestAddendum addendum)
+        {
+            string key = $"{id}_{type}";
+            bool existsInCache = lookupCache.TryGetValue(key, out addendum);
+            if (!existsInCache)
+                addendum = null;
+
+            return existsInCache;
+        }
+
+        public static VersionManifestAddendum FindInAddendums(string id, string type, List<VersionManifestAddendum> addendums)
+        {
+            UpdateCache(addendums);
+            bool wasFound = FindInCache(id, type, out VersionManifestAddendum addendum);       
+            return addendum;
+        }
+
+    }
+}

--- a/ModTek/Patches/VersionManifestAddendum.cs
+++ b/ModTek/Patches/VersionManifestAddendum.cs
@@ -63,7 +63,7 @@ namespace ModTek.Patches
         }
     }
 
-    static class VersionManifestAddendumCache
+    public static class VersionManifestAddendumCache
     {
         private static Dictionary<string, VersionManifestAddendum> lookupCache = new Dictionary<string, VersionManifestAddendum>();
 
@@ -75,7 +75,7 @@ namespace ModTek.Patches
             {
                 if (!cachedAddendums.ContainsKey(vma.Name))
                 {
-                    RLog.LogWrite($"Adding to addendum cache: {vma.Name}\n");
+                    //RLog.LogWrite($"Adding to addendum cache: {vma.Name}\n");
                     foreach (VersionManifestEntry vme in vma.Entries)
                     {
                         string entryKey = $"{vme.Id}_{vme.Type}";
@@ -102,7 +102,17 @@ namespace ModTek.Patches
         {
             UpdateCache(addendums);
             bool wasFound = FindInCache(id, type, out VersionManifestAddendum addendum);       
-            return addendum;
+            return wasFound ? addendum : null;
+        }
+
+        public static void InvalidateAddendum(VersionManifestAddendum addendum)
+        {
+            if (lookupCache.ContainsKey(addendum.Name))
+            {
+                RLog.M.WL(0, "Invalidating cache for addendum: " + addendum.Name);
+                lookupCache.Remove(addendum.Name);
+            }
+                
         }
 
     }


### PR DESCRIPTION
This PR covers two minor performance increases. When KMission added his runtime logger, he used it to log all manifest entries that were added. This adds several seconds to my modtek load, so I've put this behind a configuration gate 'EnableDebugLogging' in config.json. To accommodate this, I've repointed the configuration file to be found at ModTek/ instead of .modtek/, as /.modtek is created at runtime.

The bigger change is that this mod implements a dictionary cache for VersionManifestAddendum.GetAddendumContainingEntry calls. The vanilla code for this uses LINQ to do Contains() calls, which due to the nested nature of VersionManifestAddendum -> VersionManifestEntry is fairly painful. Instead this patch creates a cache of the VME values when the addendum is first queried, and then uses that cache for lookup. On my modtek this shaved ~4-8s off, as the VMA.GACE calls went from ~200ms -> ~75ms or ~600ms -> 100ms. These calls are performed repeatedly during the load.