### PR TITLE
ManifestLoaded to allow modifications of the manifest once its fully …

### DIFF
--- a/ModTek/Features/Manifest/BTRL/BetterBTRL.cs
+++ b/ModTek/Features/Manifest/BTRL/BetterBTRL.cs
@@ -4,7 +4,7 @@ using System.Diagnostics;
 using System.Linq;
 using BattleTech;
 using BattleTech.Data;
-using ModTek.Features.CustomResources;
+using ModTek.Features.Manifest.Mods;
 using ModTek.Util;
 using static ModTek.Features.Logging.MTLogger;
 
@@ -35,6 +35,8 @@ namespace ModTek.Features.Manifest.BTRL
 
         private void ContentPackManifestsLoaded()
         {
+            ModDefsDatabase.ManifestLoaded(currentManifest.RawManifest);
+
             currentManifest.DumpToDisk();
 
             var contentPacks = packIndex?.GetOwnedContentPacks();

--- a/ModTek/Features/Manifest/BTRL/TypedManifest.cs
+++ b/ModTek/Features/Manifest/BTRL/TypedManifest.cs
@@ -17,6 +17,8 @@ namespace ModTek.Features.Manifest.BTRL
         private readonly TypedDict manifest = new();
         private readonly Dictionary<string, HashSet<BattleTechResourceType>> idToTypes = new();
 
+        internal TypedDict RawManifest => manifest;
+
         private static readonly string ManifestDumpPath = Path.Combine(FilePaths.TempModTekDirectory, "Manifest.csv");
         private static readonly VersionManifestEntry[] emptyArray = new VersionManifestEntry[0];
 

--- a/ModTek/Features/Manifest/Mods/ModDefsDatabase.cs
+++ b/ModTek/Features/Manifest/Mods/ModDefsDatabase.cs
@@ -2,6 +2,7 @@
 using System.Collections.Generic;
 using System.IO;
 using System.Linq;
+using BattleTech;
 using ModTek.Misc;
 using ModTek.UI;
 using ModTek.Util;
@@ -281,15 +282,27 @@ namespace ModTek.Features.Manifest.Mods
                 return;
             }
 
+            Log("Calling FinishedLoading:");
+            foreach (var modDef in ModsInLoadOrder().Where(modDef => modDef.Assembly != null))
             {
-                Log("Calling FinishedLoading:");
-                foreach (var modDef in ModsInLoadOrder().Where(modDef => modDef.Assembly != null))
-                {
-                    ModDefExLoading.FinishedLoading(modDef, ModLoadOrder);
-                }
+                ModDefExLoading.FinishedLoading(modDef, ModLoadOrder);
             }
             HarmonyUtils.PrintHarmonySummary(FilePaths.HarmonySummaryPath);
             LoadOrder.ToFile(ModLoadOrder, FilePaths.LoadOrderPath);
+        }
+
+        internal static void ManifestLoaded(Dictionary<string, Dictionary<string, VersionManifestEntry>> manifest)
+        {
+            if (ModLoadOrder == null || ModLoadOrder.Count <= 0)
+            {
+                return;
+            }
+
+            Log("Calling ManifestLoaded:");
+            foreach (var modDef in ModsInLoadOrder().Where(modDef => modDef.Assembly != null))
+            {
+                ModDefExLoading.ManifestLoaded(modDef, manifest);
+            }
         }
     }
 }

--- a/ModTek/Features/Manifest/Patches/ContentPackIndex_TryFinalizeDataLoad_Patch.cs
+++ b/ModTek/Features/Manifest/Patches/ContentPackIndex_TryFinalizeDataLoad_Patch.cs
@@ -14,6 +14,7 @@ namespace ModTek.Features.Manifest.Patches
             return ModTek.Enabled;
         }
 
+        [HarmonyPriority(Priority.High)]
         public static void Postfix(ContentPackIndex __instance)
         {
             try


### PR DESCRIPTION
…indexed.

How to solve issue that each mod can modify it and each mod would need to listen to other mods changes?
Try to go the typed refresh method anyway?

Will be costly to use the external typed refresh but.. we only have to call it once right?