### PR TITLE
Added encounter layer support

### DIFF
--- a/ModTek/Features/EncounterLayers/EncounterLayer.cs
+++ b/ModTek/Features/EncounterLayers/EncounterLayer.cs
@@ -1,0 +1,43 @@
+using Newtonsoft.Json;
+
+namespace ModTek.Features.EncounterLayers
+{
+    [JsonObject]
+    internal class EncounterLayer
+    {
+        [JsonProperty("EncounterLayerID")]
+        public string EncounterLayerID { get; set; }
+
+        [JsonProperty("MapID")]
+        public string MapID { get; set; }
+
+        [JsonProperty("Name")]
+        public string Name { get; set; }
+
+        [JsonProperty("FriendlyName")]
+        public string FriendlyName { get; set; }
+
+        [JsonProperty("Description")]
+        public string Description { get; set; }
+
+        [JsonProperty("BattleValue")]
+        public string BattleValue { get; set; }
+
+        [JsonProperty("ContractTypeID")]
+        public string ContractTypeID { get; set; }
+
+        [JsonProperty("EncounterLayerGUID")]
+        public string EncounterLayerGUID { get; set; }
+
+        [JsonProperty("TagSetID")]
+        public string TagSetID { get; set; }
+
+        [JsonProperty("IncludeInBuild")]
+        public string IncludeInBuild { get; set; }
+
+        public override string ToString()
+        {
+            return $"EncounterLayer => encounterLayerID: {EncounterLayerID}  mapID: {MapID}  friendlyName: {FriendlyName}  description: {Description}  battleValue: {BattleValue} contractTypeID: {ContractTypeID} encounterLayerGUID: {EncounterLayerGUID} tagSetID {TagSetID} includeInBuild: {IncludeInBuild}";
+        }
+    }
+}

--- a/ModTek/Features/EncounterLayers/MetadataDatabaseExtensions.cs
+++ b/ModTek/Features/EncounterLayers/MetadataDatabaseExtensions.cs
@@ -1,0 +1,34 @@
+using System.Linq;
+using BattleTech.Data;
+
+namespace ModTek.Features.EncounterLayers
+{
+    internal static class MetadataDatabaseExtensions
+    {
+        public static EncounterLayer_MDD InsertOrUpdateEncounterLayer(this MetadataDatabase mdd, EncounterLayer encounterLayer)
+        {
+            mdd.Execute("INSERT OR REPLACE INTO EncounterLayer (EncounterLayerID, MapID, Name, FriendlyName, Description, BattleValue, ContractTypeID, EncounterLayerGUID, TagSetID, IncludeInBuild) values(@EncounterLayerID, @MapID, @Name, @FriendlyName, @Description, @BattleValue, @ContractTypeID, @EncounterLayerGUID, @TagSetID, @IncludeInBuild)", new
+            {
+                EncounterLayerID = encounterLayer.EncounterLayerID,
+                MapID = encounterLayer.MapID,
+                Name = encounterLayer.Name,
+                FriendlyName = encounterLayer.FriendlyName,
+                Description = encounterLayer.Description,
+                BattleValue = encounterLayer.BattleValue,
+                ContractTypeID = encounterLayer.ContractTypeID,
+                EncounterLayerGUID = encounterLayer.EncounterLayerGUID,
+                TagSetID = encounterLayer.TagSetID,
+                IncludeInBuild = encounterLayer.IncludeInBuild
+            }, null, null, null);
+            return mdd.SelectEncounterLayerByID(encounterLayer.EncounterLayerID);
+        }
+
+        public static EncounterLayer_MDD SelectEncounterLayerByID(this MetadataDatabase mdd, string encounterLayerId)
+        {
+            return mdd.Query<EncounterLayer_MDD>("SELECT * FROM EncounterLayer WHERE EncounterLayerID=@encounterLayerId", new
+            {
+                EncounterLayerID = encounterLayerId
+            }, null, true, null, null).FirstOrDefault<EncounterLayer_MDD>();
+        }
+    }
+}

--- a/ModTek/Features/Manifest/MDD/MDDBIndexer.cs
+++ b/ModTek/Features/Manifest/MDD/MDDBIndexer.cs
@@ -1,7 +1,10 @@
-﻿using BattleTech;
+using BattleTech;
 using BattleTech.Data;
 using BattleTech.Framework;
 using ModTek.Features.CustomResources;
+using ModTek.Features.EncounterLayers;
+using Newtonsoft.Json;
+using static ModTek.Features.Logging.MTLogger;
 
 namespace ModTek.Features.Manifest.MDD
 {
@@ -25,7 +28,8 @@ namespace ModTek.Features.Manifest.MDD
             var mddb = MetadataDatabase.Instance;
             if (type == InternalCustomResourceType.EncounterLayer)
             {
-                // TODO here
+                var encounterLayer = JsonConvert.DeserializeObject<EncounterLayer>(json);
+                mddb.InsertOrUpdateEncounterLayer(encounterLayer);
             }
         }
 


### PR DESCRIPTION
Implements the placeholder `EncounterLayer` manifest type. This adds the `EncounterLayer` into the MDDB.

This is critical for custom contract type support for Mission Control and allows Mission Control to no longer requiring writing to the MDDB.

For example:

```json
 { "Type": "EncounterLayer", "Path": "overrides/encounterLayers" }
```

and loading an example encounter layer of:

```json
{
  "EncounterLayerID": "mapGeneral_frostySlopes_iTnd.d8bb1d16-3a64-40a9-a081-03a365fd0fcf",
  "MapID": "mapGeneral_frostySlopes_iTnd",
  "Name": "encMC_Blackout",
  "FriendlyName": "Blackout",
  "Description": "Player must investigate the cause of the blackout.",
  "BattleValue": "0",
  "ContractTypeID": "10002",
  "EncounterLayerGUID": "d8bb1d16-3a64-40a9-a081-03a365fd0fcf",
  "TagSetID": "mapGeneral_frostySlopes_iTnd.d8bb1d16-3a64-40a9-a081-03a365fd0fcf",
  "IncludeInBuild": "1"
}

```

Sadly, the `EncounterLayer_MDD` file doesn't have a nice way to load the json data into it unlike some classes, so I load it up into a class and then save it into the MDDB. This is similar to how the ModTek CustomTags support works.