### PR TITLE
set LD_LIBRARY_PATH

### DIFF
--- a/ModTek.Preloader/run.sh
+++ b/ModTek.Preloader/run.sh
@@ -63,6 +63,7 @@ case ${os_type} in
     #Work around used as it is a bug that is patched out in newer versions of mono.
     export TERM=xterm
 
+    #LD_PRELOAD can't handle whitespaces as good as LD_LIBRARY_PATH
     export LD_LIBRARY_PATH="${BASEDIR}"
     export LD_PRELOAD="libdoorstop.so:${LD_PRELOAD:-}"
     LD_PRELOAD="${LD_PRELOAD%:}"

--- a/ModTek.Preloader/run.sh
+++ b/ModTek.Preloader/run.sh
@@ -63,7 +63,8 @@ case ${os_type} in
     #Work around used as it is a bug that is patched out in newer versions of mono.
     export TERM=xterm
 
-    export LD_PRELOAD="${BASEDIR}/libdoorstop.so:${LD_PRELOAD:-}"
+    export LD_LIBRARY_PATH="${BASEDIR}"
+    export LD_PRELOAD="libdoorstop.so:${LD_PRELOAD:-}"
     LD_PRELOAD="${LD_PRELOAD%:}"
   ;;
   Darwin*)


### PR DESCRIPTION
Sometimes LD_PRELOAD doesn't like spaces in the path.  We can often work around it by using LD_LIBRARY_PATH with the path containing spaces so that LD_PRELOAD doesn't have to.